### PR TITLE
add executable permission to bootstrap binary

### DIFF
--- a/aws-build-lib/src/lib.rs
+++ b/aws-build-lib/src/lib.rs
@@ -358,6 +358,7 @@ impl Builder {
                 ))?;
                 let mut zip = ZipWriter::new(file);
                 let options = zip::write::FileOptions::default()
+                    .unix_permissions(0o755)
                     .compression_method(zip::CompressionMethod::Deflated);
                 zip.start_file("bootstrap", options)?;
                 zip.write_all(&bin_contents)?;


### PR DESCRIPTION
aws-sam maybe behaves slightly differently to aws since it doesn't seem to work if the bootstrap binary inside the lambda.zip is missing the executable permission. perhaps aws cloud checks the permission and overrides it.

example local testing process to replicate (example assumes cloudformation template created using cdk):

```
cdk synth --no-staging > template.yaml
sam local invoke $FUNCTION
```
