### PR TITLE
aws-build-lib: add option to relabel files

### DIFF
--- a/aws-build/src/main.rs
+++ b/aws-build/src/main.rs
@@ -99,6 +99,7 @@ fn main() {
         launcher,
         project: opt.project,
         packages: opt.package,
+        relabel: None,
     };
     builder.run()?;
 }


### PR DESCRIPTION
This may be necessary on systems with selinux enabled. For now it is
only exposed in the library, not the executable.