### PR TITLE
aws-build-lib: add code_root and tests

### DIFF
--- a/aws-build-lib/src/container/Dockerfile
+++ b/aws-build-lib/src/container/Dockerfile
@@ -19,6 +19,9 @@ ADD build.sh /build.sh
 RUN chmod +x /build.sh
 
 VOLUME ["/code"]
-WORKDIR /code
+
+# Change to the project directory.
+ARG PROJECT_PATH
+WORKDIR /code/"$PROJECT_PATH"
 
 ENTRYPOINT ["/build.sh"]

--- a/aws-build/src/main.rs
+++ b/aws-build/src/main.rs
@@ -97,7 +97,10 @@ fn main() {
         bin: opt.bin,
         strip: opt.strip,
         launcher,
-        project: opt.project,
+        // TODO: add an argument to control code root independently from
+        // project_path.
+        code_root: opt.project.clone(),
+        project_path: opt.project,
         packages: opt.package,
         relabel: None,
     };


### PR DESCRIPTION
This allows an arbitrary path to be mounted into the container
containing all the code. The project path must be a subdirectory of the
code root.

This option is not yet exposed in the bin.