### PR TITLE
aws-build: use a crates.io dep on aws-build-lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,6 @@ members = [
     "xtask",
 ]
 exclude = ["container_tests"]
+
+[patch.crates-io]
+aws-build-lib = { path = "aws-build-lib" }

--- a/aws-build/Cargo.toml
+++ b/aws-build/Cargo.toml
@@ -11,7 +11,7 @@ readme = "../README.md"
 repository = "https://github.com/nicholasbishop/aws-build"
 
 [dependencies]
-aws-build-lib = { path = "../aws-build-lib" }
+aws-build-lib = { version = "0.9.3", default-features = false }
 
 anyhow = { version = "1.0.45", default-features = false, features = ["std"] }
 argh = { version = "0.1.6", default-features = false }


### PR DESCRIPTION
For the local build, set a patch override in the top-level Cargo.toml.